### PR TITLE
Rename collections to collections.abc

### DIFF
--- a/vk/utils.py
+++ b/vk/utils.py
@@ -1,5 +1,5 @@
 import logging
-from collections import Iterable
+from collections.abc import Iterable
 
 logger = logging.getLogger('vk')
 


### PR DESCRIPTION
Fix module import "collections" for python 3.10