### PR TITLE
Log warning if errors are occured during the execute method

### DIFF
--- a/src/vk/exceptions.py
+++ b/src/vk/exceptions.py
@@ -25,6 +25,7 @@ class VkAPIError(VkException):
     def __init__(self, error_data):
         super(VkAPIError, self).__init__()
         self.error_data = error_data
+        self.method = error_data.get('method')
         self.code = error_data.get('error_code')
         self.message = error_data.get('error_msg')
         self.request_params = self.get_pretty_request_params(error_data)

--- a/src/vk/session.py
+++ b/src/vk/session.py
@@ -53,14 +53,15 @@ class APIBase:
         request.response = response_or_error
 
         if 'response' in response_or_error:
-            # todo Can we have error and response simultaneously
-            # for error in errors:
-            #     logger.warning(str(error))
+
+            for error_data in response_or_error.get('execute_errors', ()):
+                api_error = VkAPIError(error_data)
+                logger.warning('Execute "%s" error: %s', api_error.method, api_error)
+
             return response_or_error['response']
 
         elif 'error' in response_or_error:
-            api_error = VkAPIError(request.response['error'])
-            request.api_error = api_error
+            request.api_error = VkAPIError(request.response['error'])
             return self.handle_api_error(request)
 
     def prepare_request(self, request):  # noqa: U100

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from vk import API
@@ -9,8 +11,17 @@ def api(access_token, v):
 
 
 def test_durov(api):
-    """
-    Get users
-    """
-    users = api.users.get(user_id=1)
+    users = api.users.get(user_ids=1)
     assert users[0]['last_name'] == 'Durov'
+
+
+def test_execute(caplog, api):
+    with caplog.at_level(logging.WARNING, logger='vk'):
+        api.execute(code='var x = API.storage.get(); '
+                         'return API.users.get({user_ids: 1});')
+
+    assert len(caplog.records) == 1
+
+    log = caplog.records[0]
+    assert log.levelno == logging.WARNING
+    assert 'Execute "storage.get" error' in log.message


### PR DESCRIPTION
Если во время вызова метода `execute` произошли ошибки, они будут записаны в логе с уровнем *WARNING*
Исправляет #42 